### PR TITLE
Memoize rspec-puppet-facts

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -28,6 +28,15 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
+# Generating facts is slow - this memoizes the facts between multiple classes.
+# Marshalling is used to get unique instances which helps when tests overrides
+# facts.
+FACTS_CACHE = {}
+def on_supported_os(opts = {})
+  result = FACTS_CACHE[opts.to_s] ||= super(opts)
+  Marshal.load(Marshal.dump(result))
+end
+
 RSpec.configure do |config|
   config.default_facter_version = suggest_facter_version
 


### PR DESCRIPTION
Collection of facts can be slow. By memoizing subsequent calls are sped up greatly.

In puppet-nginx test collection was reduced from 1 minute 52 seconds down to 15 seconds. That has 9 calls to on_supported_os.