### PR TITLE
Define a default task

### DIFF
--- a/lib/voxpupuli/test/rake.rb
+++ b/lib/voxpupuli/test/rake.rb
@@ -5,6 +5,8 @@ PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{messag
 desc 'Run tests'
 task test: [:release_checks]
 
+task default: [:release_checks]
+
 namespace :check do
   desc 'Check for trailing whitespace'
   task :trailing_whitespace do


### PR DESCRIPTION
By defining the default task, there is no separate Travis configuration needed and it works out of the box.