### PR TITLE
Add rspec matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,67 @@ In your `spec/spec_helper.rb`
 ```ruby
 require 'voxpupuli/test/spec_helper'
 ```
+
+# Additional matchers
+
+Suppose there's the following Puppet definition, it can be tested as follows:
+
+```puppet
+$content = @(END)
+# See the qdrouterd.conf (5) manual page for information about this
+# file's format and options.
+
+router {
+  id: ${facts['networking']['fqdn']}
+  mode: interior
+  worker-threads: ${facts['processors']['count']}
+}
+END
+
+concat::fragment { 'qdrouter+header.conf':
+  target  => '/etc/qpid-dispatch/qdrouterd.conf,
+  content => $content,
+  order   => '01',
+}
+```
+
+Normally this can be verified using `contain_concat__fragment('qdrouter+header.conf').with_content()`, but that means you have to specify all comments as well. Usually those are not very interesting. Another option is to use [verify_contents](https://github.com/puppetlabs/puppetlabs_spec_helper/blob/070ecb79a63cb8fa10f46532c413c055e2697682/lib/puppetlabs_spec_helper/module_spec_helper.rb#L9-L12) from [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec_helper) but that has an awkward syntax and is limited to `file` resources.
+
+This gem patches [rspec-puppet](https://rspec-puppet.com/) to provide `that_has_content` and `that_has_exact_content` matchers on resources. That means there's now two ways to test tour code.
+
+
+```ruby
+# Classic way: just verify the line with a variable
+it do
+  is_expected.to contain_concat__fragment('qdrouter+header.conf')
+    .with_content(%r{^    id: foo\.example\.com$})
+    .with_content(%r{^    worker-threads: 2$})
+end
+```
+
+```ruby
+# Verify some lines are present and correct, ignore some
+it do
+  is_expected.to contain_concat__fragment('qdrouter+header.conf').that_has_content(
+    <<~CONTENT
+          id: foo.example.com
+          worker-threads: 2
+    CONTENT
+  )
+end
+```
+
+```ruby
+# Verify all non-comment lines match exactly
+it do
+  is_expected.to contain_concat__fragment('qdrouter+header.conf').that_has_exact_content(
+    <<~CONTENT
+      router {
+          id: foo.example.com
+          mode: interior
+          worker-threads: 2
+      }
+    CONTENT
+  )
+end
+```

--- a/lib/voxpupuli/test/matchers.rb
+++ b/lib/voxpupuli/test/matchers.rb
@@ -1,0 +1,111 @@
+require 'rspec-puppet'
+
+class LineParameterMatcher < RSpec::Puppet::ManifestMatchers::ParameterMatcher
+  def initialize(parameter, value, type, exact, strip_comments = true)
+    super(parameter, value, type)
+
+    @exact = exact
+    @strip_comments = strip_comments
+  end
+
+  def get_lines(resource)
+    value = resource[@parameter]
+
+    lines = if value.is_a?(String)
+              value.split("\n")
+            elsif value.is_a?(Array)
+              value
+            end
+
+    return unless lines
+
+    if @strip_comments
+      lines = lines.reject { |line| line =~ /^(\s*#|$)/ }
+    end
+
+    unless @exact
+      lines = lines & @value.split("\n")
+    end
+
+    lines.join("\n")
+  end
+
+  # Ensure that the actual parameter matches the expected parameter.
+  #
+  # @param resource [Hash<Symbol, Object>] A hash representing a Puppet
+  #   resource in the catalog
+  #
+  # @return [true, false]
+  def matches?(resource)
+    actual = get_lines(resource)
+    return false unless actual
+
+    expected = @value.rstrip
+
+    retval = check(expected, actual)
+
+    unless retval
+      @errors << MatchError.new(@parameter, expected, actual, !@should_match)
+    end
+
+    retval
+  end
+end
+
+module MatcherExtensions
+  def initialize(*args, &block)
+    super(*args, &block)
+
+    @expected_line_params = []
+  end
+
+  def that_has_content(content)
+    @expected_line_params << ['content', content, false]
+    self
+  end
+
+  def that_has_exact_content(content)
+    @expected_line_params << ['content', content, true]
+    self
+  end
+
+  def matches?(catalogue)
+    result = super(catalogue)
+    return result unless @catalogue
+
+    resource = @catalogue.resource(@referenced_type, @title)
+    return result unless resource
+
+    check_line_params(resource, @expected_line_params, :should)
+
+    @errors.empty?
+  end
+
+  # @param resource [Hash<Symbol, Object>] The resource in the catalog
+  # @param list [Array<String, Object>] The expected values of the resource
+  # @param type [:should, :not] Whether the given parameters should/not match
+  def check_line_params(resource, list, type)
+    list.each do |param, value, exact|
+      param = param.to_sym
+
+      if value.nil? then
+        unless resource[param].nil?
+          @errors << "#{param} undefined but it is set to #{resource[param].inspect}"
+        end
+      else
+        m = LineParameterMatcher.new(param, value, type, exact)
+        unless m.matches?(resource)
+          @errors.concat m.errors
+        end
+      end
+    end
+  end
+end
+
+module RSpec::Puppet
+  module ManifestMatchers
+    class CreateGeneric
+      prepend MatcherExtensions
+    end
+  end
+end

--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   end
 end
 
+require 'voxpupuli/test/matchers'
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts


### PR DESCRIPTION
This is currently a draft because I want feedback on the API. The goal is to replace helper functions in Foreman's modulesync with proper rspec matchers: https://github.com/theforeman/foreman-installer-modulesync/blob/0303d8769398485c1d41accb2a9f7a944707e1f2/moduleroot/spec/spec_helper.rb.erb#L54-L74

These are based on helpers in puppetlabs_spec_helper: https://github.com/puppetlabs/puppetlabs_spec_helper/blob/070ecb79a63cb8fa10f46532c413c055e2697682/lib/puppetlabs_spec_helper/module_spec_helper.rb#L5-L12

The nuance is that we're filtering out comments and that feels like an odd API. In this PR I've also changed the content from an array of lines to a long string. Not sure if that's the best API either, but it looks more natural when you type them.

I've considered naming it `that_has_parsed_content` but parsing is also a bit odd since not everything is parsed in the same way. JSON has no comments at all for example but this still filters them out.