### PR TITLE
Add puppet-lint-spaceship_operator_without_tag-check

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-manifest_whitespace-check'
   s.add_runtime_dependency 'puppet-lint-file_ensure-check'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'
+  s.add_runtime_dependency 'puppet-lint-spaceship_operator_without_tag-check'
 
   # development
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
I tested this for my own modules already, also heavily used in the
foreman ecosystem.