### PR TITLE
Remove fact memoization

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -27,15 +27,6 @@ end
 require 'voxpupuli/test/facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
-# Generating facts is slow - this memoizes the facts between multiple classes.
-# Marshalling is used to get unique instances which helps when tests overrides
-# facts.
-FACTS_CACHE = {}
-def on_supported_os(opts = {})
-  result = FACTS_CACHE[opts.to_s] ||= super(opts)
-  Marshal.load(Marshal.dump(result))
-end
-
 RSpec.configure do |config|
   config.default_facter_version = suggest_facter_version
 

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'metadata-json-lint'
   s.add_runtime_dependency 'parallel_tests'
   s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.14.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '>= 1.9.5'
+  s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
 
   # Rubocop


### PR DESCRIPTION
This already happens in rspec-puppet-facts itself and there's no reason to duplicate it. There it's also more correct by taking all variables into account.

Draft because it depends on https://github.com/mcanevet/rspec-puppet-facts/pull/122 being merged and released as 2.1.0.