### PR TITLE
Disable Style/TrailingCommaInLiteral

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -333,7 +333,7 @@ Style/TrailingCommaInArguments:
   Enabled: True
 
 Style/TrailingCommaInLiteral:
-  Enabled: True
+  Enabled: False
 
 Style/GlobalVars:
   Enabled: True


### PR DESCRIPTION
When this is enabled, trailing comma's for elements in a hash are not allowed. This is not the style that Puppet uses and causes code churn. This change would disable that functionality.