### PR TITLE
Revert "Pin `rspec-expectations`"

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -22,9 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 1.9.5'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
 
-  # avoid breaking change until https://github.com/rodjek/rspec-puppet/pull/811 is released
-  s.add_runtime_dependency 'rspec-expectations', '< 3.10.0'
-
   # Rubocop
   s.add_runtime_dependency 'rubocop', '~> 0.49.1'
   s.add_runtime_dependency 'rubocop-rspec', '~> 1.16.0'


### PR DESCRIPTION
This reverts commit 692fa31ad9ba3091b348908c0e03d4acd9f84d7a.

A new version of rspec-puppet has been released, and this pin should no
longer be necessary (and may have been causing some other issues of its
own).