### PR TITLE
Disable Style/TrailingCommaInArguments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -161,6 +161,9 @@ Style/BracesAroundHashParameters:
 Style/CaseEquality:
   Enabled: True
 
+Style/TrailingCommaInArguments:
+  Enabled: False
+
 Layout/CaseIndentation:
   Enabled: True
 


### PR DESCRIPTION
Currently the trailing , in

```ruby
it {
  is_expected.to contain_concat__fragment('nftables-inet-filter-chain-default_out-rule-dnsudp').with(
    target:  'nftables-inet-filter-chain-default_out',
    content: %r{^  udp dport 53 accept$},
    order:   '50-nftables-inet-filter-chain-default_out-rule-dnsudp-b',
  )
}
```

throws a warning. This is inconsistent with what is permitted in
puppet.