### PR TITLE
Enhance check task for trailing whitespace

### DIFF
--- a/lib/voxpupuli/test/rake.rb
+++ b/lib/voxpupuli/test/rake.rb
@@ -21,4 +21,5 @@ namespace :check do
     end
   end
 end
-Rake::Task[:release_checks].enhance ['check:trailing_whitespace']
+
+task :check => 'check:trailing_whitespace'

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -12,13 +12,15 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['lib/**/*.rb', 'rubocop.yml']
 
+  s.required_ruby_version = '>= 2.4.0'
+
   s.add_runtime_dependency 'rake'
 
   # Testing
   s.add_runtime_dependency 'facterdb', '>= 1.4.0'
   s.add_runtime_dependency 'metadata-json-lint'
   s.add_runtime_dependency 'parallel_tests'
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.14.0'
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 3.0.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 1.9.5'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
 


### PR DESCRIPTION
puppetlabs_spec_helper 3.0.0 introduces a check task for various checks. This is a more natural place than release_checks.

It also specifies the lower bound Ruby version as 2.4.0, following puppetlabs_spec_helper 3.0.0.

At this moment untested, but submitting my local modifications as PRs.