### PR TITLE
add puppet-lint-optional_default-check

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-manifest_whitespace-check'
   s.add_runtime_dependency 'puppet-lint-file_ensure-check'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'
+  s.add_runtime_dependency 'puppet-lint-optional_default-check'
 
   # development
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
Hi,
@alexjfisher I checked out your linter plugin and it seems to work fine. I also found some params that indeed assign data to an undef var so I think it's a useful addition to our linting and works fine.