### PR TITLE
Depend on puppet-lint >= 2.5.0

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubocop-rspec', '~> 1.16.0'
 
   # Linting
+  # pull in 2.5.0; required for Ruby 3 support
+  s.add_runtime_dependency 'puppet-lint', '>= 2.5.0'
   s.add_runtime_dependency 'puppet-lint-absolute_classname-check', '>= 2.0.0'
   s.add_runtime_dependency 'puppet-lint-anchor-check'
   s.add_runtime_dependency 'puppet-lint-classes_and_types_beginning_with_digits-check'


### PR DESCRIPTION
puppet-lint is required for Ruby 3 support.