### PR TITLE
require puppetlabs_spec_helper 4

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'facterdb', '>= 1.4.0'
   s.add_runtime_dependency 'metadata-json-lint'
   s.add_runtime_dependency 'parallel_tests'
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.14.0'
+  # 4.0.0 provides rubocop annotations in GitHub Actions
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 4.0.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
 


### PR DESCRIPTION
4.0.0 provides rubocop annotations in GitHub Actions. This version was
tested in https://github.com/voxpupuli/puppet-wireguard/pull/9.