### PR TITLE
Add metadata_json_deps + rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ end
 ```
 
 Note that this helper deals with symbols/strings for you as well.
+
+# Identify dependencies from metadata.json that aren't up2date
+
+This gem provides the `check:metadata_deps` rake task:
+
+```console
+$ bundle exec rake check:metadata_deps
+Checking metadata.json
+  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
+```

--- a/lib/voxpupuli/test/rake.rb
+++ b/lib/voxpupuli/test/rake.rb
@@ -1,4 +1,5 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'metadata_json_deps'
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
 
@@ -22,3 +23,10 @@ namespace :check do
   end
 end
 Rake::Task[:release_checks].enhance ['check:trailing_whitespace']
+
+
+desc 'Run metadata-json-deps'
+task :metadata_deps do
+  files = FileList['metadata.json']
+  MetadataJsonDeps::run(files)
+end

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.14.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
+  s.add_runtime_dependency 'metadata_json_deps', '>= 0.2.0'
 
   # Rubocop
   s.add_runtime_dependency 'rubocop', '~> 0.49.1'


### PR DESCRIPTION
I tested this successfully on the bird module:
```
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ git diff
diff --git a/Gemfile b/Gemfile
index 930d8da..57e246a 100644
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"

 group :test do
-  gem 'voxpupuli-test', '~> 2.1',  :require => false
+  #gem 'voxpupuli-test', '~> 2.1',  :require => false
+  gem 'voxpupuli-test', git: 'https://github.com/bastelfreak/voxpupuli-test.git', branch: 'msp'
   gem 'coveralls',                 :require => false
   gem 'simplecov-console',         :require => false
   gem 'puppet-lint-param-docs',    :require => false
+  #gem 'metadata_json_deps', git: 'https://github.com/bastelfreak/metadata_json_deps', branch: '3'
 end

 group :development do
diff --git a/metadata.json b/metadata.json
index dd9a75a..400591d 100644
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 8.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ],
   "requirements": [
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ bundle exec rake check:metadata_deps
Checking metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ git checkout -- metadata.json
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ bundle exec rake check:metadata_deps
Checking metadata.json
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ echo $?
0
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $
```