### PR TITLE
require metadata-json-lint 3 or newer/metadata_json_deps 0.3.0 or newer

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |s|
 
   # Testing
   s.add_runtime_dependency 'facterdb', '>= 1.4.0'
-  s.add_runtime_dependency 'metadata-json-lint'
+  s.add_runtime_dependency 'metadata-json-lint', '>= 3.0.1'
   s.add_runtime_dependency 'parallel_tests'
   s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.16.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
-  s.add_runtime_dependency 'metadata_json_deps', '>= 0.2.0'
+  s.add_runtime_dependency 'metadata_json_deps', '>= 0.3.0'
 
   # Rubocop
   s.add_runtime_dependency 'rubocop', '~> 0.49.1'


### PR DESCRIPTION
This ensures we get at least metadata-json-lint 3 and not the way older 3.