### PR TITLE
Revert "Add metadata_json_deps + rake task"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,3 @@ end
 ```
 
 Note that this helper deals with symbols/strings for you as well.
-
-# Identify dependencies from metadata.json that aren't up2date
-
-This gem provides the `check:metadata_deps` rake task:
-
-```console
-$ bundle exec rake check:metadata_deps
-Checking metadata.json
-  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
-```

--- a/lib/voxpupuli/test/rake.rb
+++ b/lib/voxpupuli/test/rake.rb
@@ -1,5 +1,4 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'metadata_json_deps'
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
 
@@ -23,10 +22,3 @@ namespace :check do
   end
 end
 Rake::Task[:check].enhance ['check:trailing_whitespace']
-
-
-desc 'Run metadata-json-deps'
-task :metadata_deps do
-  files = FileList['metadata.json']
-  MetadataJsonDeps::run(files)
-end

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 2.16.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
-  s.add_runtime_dependency 'metadata_json_deps', '>= 0.3.0'
 
   # Rubocop
   s.add_runtime_dependency 'rubocop', '~> 0.49.1'


### PR DESCRIPTION
This reverts commit 86db8faf9b6d7c89cc315c8921c7a94ccff3fcae.

The gettext-setup gem causes some ugly errors on our side:
* https://github.com/puppetlabs/forge-ruby/pull/91
* https://github.com/voxpupuli/puppet-mosquitto/pull/18
* https://tickets.puppetlabs.com/browse/MODULES-6598