### PR TITLE
Require voxpupuli-puppet-lint-plugins 2.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   # Linting
   # meta gem to pull in all puppet-lint plugins + puppet-lint itself
-  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '~> 1.0'
+  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '~> 2.0'
 
   # development
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
This will pull in puppet-lint-top_scope_facts-check. We did prio checks
and fixed the violations in all common used modules we have.