### PR TITLE
puppet-lint: fail on warnings

### DIFF
--- a/lib/voxpupuli/test/rake.rb
+++ b/lib/voxpupuli/test/rake.rb
@@ -1,6 +1,8 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 
 PuppetLint.configuration.log_format = '%{path}:%{line}:%{check}:%{KIND}:%{message}'
+# without this, puppet-lint always gives an exit code of 0
+PuppetLint.configuration.fail_on_warnings = true
 
 desc 'Run tests'
 task test: [:release_checks]


### PR DESCRIPTION
I am pretty sure that in the past we failed on puppet-lint already. with
our latest setup we continue in the CI pipeline even if puppet-lint
detects issues. This might be caused by the recent
puppetlabs_spec_helper update.