### PR TITLE
Set facter implementation to rspec

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -11,6 +11,12 @@ require 'voxpupuli/test/facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
+  # This completely disables Facter and uses a stubbed implementation. This is
+  # fine since we use use rspec-puppet-facts to set all facts. It gives
+  # complete isolation from the host system. It only works with Puppet 6.25+
+  # and 7.12+ and requires rspec-puppet 2.11.0+.
+  config.facter_implementation = 'rspec'
+
   config.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'parallel_tests'
   # 4.0.0 provides rubocop annotations in GitHub Actions
   s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 4.0.0'
+  s.add_runtime_dependency 'rspec-puppet', '>= 2.11.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
 


### PR DESCRIPTION
This completely disables Facter and uses a stubbed implementation. This is fine since we use use rspec-puppet-facts to set all facts. It gives complete isolation from the host system and is also significantly faster with Facter 4 (which always also resolves the facts, see [FACT-3039]).  It only works with Puppet 6.25+ and 7.12+ and requires rspec-puppet 2.11.0+.

FACT-3039: https://tickets.puppetlabs.com/browse/FACT-3039