### PR TITLE
Disable `Lint/BooleanSymbol`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -504,6 +504,10 @@ Lint/UselessAssignment:
 Layout/ClosingParenthesisIndentation:
   Enabled: True
 
+# Boolean symbols are used quite extensively in Puppet types/providers
+Lint/BooleanSymbol:
+  Enabled: False
+
 # RSpec
 
 RSpec/BeforeAfterAll:


### PR DESCRIPTION
In the Puppet world, symbols are often used instead of proper booleans
in type properties, (which don't work with actual booleans).
Since we probably have more false positives than real cases we should
disable this cop.