### PR TITLE
Rubocop: Disable ImplicitSubject

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -652,3 +652,5 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 RSpec/Rails/AvoidSetupHook: # new in 2.4
   Enabled: true
+RSpec/ImplicitSubject:
+  Enabled: false


### PR DESCRIPTION
Enabling this cop causes a lot of noise in our project, because ruboop
would want us to reformat most of the tests.

Explanation of the cop:
https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject