### PR TITLE
rubocop: Disable Style/OptionalBooleanParameter

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -614,6 +614,8 @@ Style/RedundantArgument: # (new in 1.4)
   Enabled: true
 Style/SwapValues: # (new in 1.1)
   Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: false
 Layout/LineEndStringConcatenationIndentation: # new in 1.18
   Enabled: true
 Lint/AmbiguousOperatorPrecedence: # new in 1.21


### PR DESCRIPTION
Example [here](https://github.com/voxpupuli/puppet-mongodb/blob/master/lib/puppet/functions/mongodb_password.rb#L12)

Changing this to `sensitive: false` causes spec to fail with `ArgumentError:  wrong number of arguments (given 3, expected 2)`
I've seen this failing in other modules as well. Possibly related to #66 