### PR TITLE
rubocop: Naming/MethodParameterName: Add common short parameters names to AllowedNames

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -557,6 +557,9 @@ RSpec/ContextWording:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
+Naming/MethodParameterName:
+  AllowedNames: ['at', 'by', 'to', 'db', 'id', 'in', 'io', 'ip', 'of', 'on', 'os', 'pp', 'is']
+
 # New cops available after rubocop upgrade
 Gemspec/DateAssignment: # (new in 1.10)
   Enabled: true


### PR DESCRIPTION
Example:

```ruby
def insync?(is)
```

That `is` parameter is all over the place in our modules.