### PR TITLE
Layout/HashAlignment: Allow both key and table styles

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -139,6 +139,8 @@ Layout/ArrayAlignment:
 
 Layout/HashAlignment:
   Enabled: True
+  EnforcedHashRocketStyle: [key, table]
+  EnforcedColonStyle: [key, table]
 
 Layout/ParameterAlignment:
   Enabled: True


### PR DESCRIPTION
In the latest modulesync rubocop was auto-correcting:

```ruby
{
   "foo"    => "bar",
   "forbar" => "bar"
}
```

to 

```ruby
{
   "foo" => "bar",
   "forbar" => "bar"
}
```

Generally in the puppet world we are used to align to the => and a lot of specs are written this way (and I think it's better to stay this way)