### PR TITLE
Correct systemd custom fact implementation

### DIFF
--- a/lib/voxpupuli/test/facts.rb
+++ b/lib/voxpupuli/test/facts.rb
@@ -85,7 +85,7 @@ def add_stdlib_facts
     when 'openbsd'
       'openbsd'
     when 'redhat'
-      facts[:operatingsystemrelease].to_i >= 7 ? 'systemd' : 'redhat'
+      facts[:operatingsystemmajrelease].to_i >= 7 ? 'systemd' : 'redhat'
     when 'suse'
       facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
     when 'windows'

--- a/lib/voxpupuli/test/facts.rb
+++ b/lib/voxpupuli/test/facts.rb
@@ -51,7 +51,7 @@ def add_facts_for_metadata(metadata)
   metadata['dependencies'].each do |dependency|
     case normalize_module_name(dependency['name'])
     when 'camptocamp/systemd', 'puppet/systemd'
-      add_custom_fact :systemd, ->(os, facts) { facts[:service_provider] == 'systemd' }
+      add_custom_fact :systemd, ->(os, facts) { facts['service_provider'] == 'systemd' }
     when 'puppetlabs/stdlib'
       add_stdlib_facts
     end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -91,3 +91,77 @@ describe 'override_facts' do
     it { expect(override_facts(base_facts, os: {'release' => {minor: '8'}})).to eq(expected) }
   end
 end
+
+describe 'add_facts_for_metadata' do
+  before(:each) { RspecPuppetFacts.reset }
+  after(:each) { RspecPuppetFacts.reset }
+
+  let(:metadata) do
+    { 'dependencies' => dependencies }
+  end
+
+  context 'without dependencies' do
+    let(:dependencies) { [] }
+
+    it 'does not call add_custom_fact' do
+      expect(RspecPuppetFacts).not_to receive(:register_custom_fact)
+      add_facts_for_metadata(metadata)
+    end
+  end
+
+  context 'with systemd' do
+    let(:dependencies) do
+      [
+        {'name' => 'puppet/systemd'},
+      ]
+    end
+
+    it 'adds the systemd fact' do
+      expect(RspecPuppetFacts).to receive(:register_custom_fact).with(:systemd, instance_of(Proc), {})
+      add_facts_for_metadata(metadata)
+    end
+
+    context 'and stdlib' do
+      let(:dependencies) do
+        [
+          {'name' => 'puppetlabs/stdlib'},
+          {'name' => 'puppet/systemd'},
+        ]
+      end
+
+      it 'has systemd on Red Hat 7' do
+        add_facts_for_metadata(metadata)
+        facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {osfamily: 'RedHat', operatingsystemmajrelease: '7'})
+        expect(facts['systemd']).to be true
+      end
+
+      it 'has no systemd on Red Hat 6' do
+        add_facts_for_metadata(metadata)
+        facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {osfamily: 'RedHat', operatingsystemmajrelease: '6'})
+        expect(facts['systemd']).to be false
+      end
+
+      it 'has no systemd on openbsd' do
+        add_facts_for_metadata(metadata)
+        facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {osfamily: 'OpenBSD'})
+        expect(facts['systemd']).to be false
+      end
+    end
+  end
+
+  context 'with stdlib' do
+    let(:dependencies) do
+      [
+        {'name' => 'puppetlabs/stdlib'},
+      ]
+    end
+
+    it 'adds the systemd fact' do
+      expect(RspecPuppetFacts).to receive(:register_custom_fact).with(:puppet_environmentpath, '/etc/puppetlabs/code/environments', {})
+      expect(RspecPuppetFacts).to receive(:register_custom_fact).with(:puppet_vardir, '/opt/puppetlabs/puppet/cache', {})
+      expect(RspecPuppetFacts).to receive(:register_custom_fact).with(:root_home, '/root', {})
+      expect(RspecPuppetFacts).to receive(:register_custom_fact).with(:service_provider, instance_of(Proc), {})
+      add_facts_for_metadata(metadata)
+    end
+  end
+end


### PR DESCRIPTION
Since rspec-puppet-facts 1.9.5 (and in particular https://github.com/mcanevet/rspec-puppet-facts/commit/21b679f45b9e20902af53161b5e1bd0b4fb723f7) custom facts are stored as strings. Since this gem requires rspec-puppet-facts >= 2.0.1 they should be treated as such.

This also highlighted that we're incompatible with `RSpec.configuration.facterdb_string_keys` set to true, but most testing code in Vox Pupuli is incompatible with this.

Tests are added to ensure it really works and prevents future regressions.

It also changes the `service_provider` custom fact to use the operatingsystemmajrelease fact. This makes testing easier and it's consistent with the code for SuSE.