### PR TITLE
require PSH 5.x, require puppet-strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,19 @@
 source 'https://rubygems.org'
 
+# Find a location or specific version for a gem. place_or_version can be a
+# version, which is most often used. It can also be git, which is specified as
+# `git://somewhere.git#branch`. You can also use a file source location, which
+# is specified as `file://some/location/on/disk`.
+def location_for(place_or_version, fake_version = nil)
+  if place_or_version =~ /^(https[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place_or_version =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place_or_version, { :require => false }]
+  end
+end
+
 gemspec
 
 group :release do

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,5 @@
 source 'https://rubygems.org'
 
-# Find a location or specific version for a gem. place_or_version can be a
-# version, which is most often used. It can also be git, which is specified as
-# `git://somewhere.git#branch`. You can also use a file source location, which
-# is specified as `file://some/location/on/disk`.
-def location_for(place_or_version, fake_version = nil)
-  if place_or_version =~ /^(https[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place_or_version =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place_or_version, { :require => false }]
-  end
-end
-
 gemspec
 
 group :release do

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -21,7 +21,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'metadata-json-lint', '>= 3.0.1'
   s.add_runtime_dependency 'parallel_tests'
   # 4.0.0 provides rubocop annotations in GitHub Actions
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 4.0.0'
+  # 5.0.0 supports the validation of REFERENCE.md
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 5.0.3'
+  # lazy dependency of the `validate` task. Will check the REFERENCE.md
+  # 3.0.0 and later require Ruby 2.7
+  s.add_runtime_dependency 'puppet-strings', '>= 2.9', '< 4'
   s.add_runtime_dependency 'rspec-puppet', '>= 2.11.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
   s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'


### PR DESCRIPTION
with the release of puppetlabs_spec_helper 5, it can validate the REFERENCE.md. It won't pull in puppet-strings automatically, so the dependency needs to be added. The `strings:validate:reference` task is called within `validate`.