### PR TITLE
Enhance CI with more Ruby/Puppet versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - ruby: "2.5"
+        ruby:
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+        puppet:
+          - "~> 7.0"
+          - "~> 6.29"
+        exclude:
           - ruby: "2.6"
-          - ruby: "2.7"
-          - ruby: "3.0"
+            puppet: "~> 7.0"
+          - ruby: "2.5"
+            puppet: "~> 7.0"
+
           - ruby: "3.1"
-            coverage: "yes"
+            puppet: "~> 6.29"
+          - ruby: "3.0"
+            puppet: "~> 6.29"
+
+    name: "Ruby ${{ matrix.ruby }} - Puppet ${{ matrix.puppet }}"
     env:
-      COVERAGE: ${{ matrix.coverage }}
+      PUPPET_VERSION: ${{ matrix.puppet }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ group :coverage, optional: ENV['COVERAGE']!='yes' do
   gem 'simplecov-console', :require => false
   gem 'codecov', :require => false
 end
+
+# Override gemspec for CI matrix builds.
+puppetversion = ENV['PUPPET_VERSION'] || '>= 6.29'
+gem 'puppet', puppetversion, :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,4 @@ group :coverage, optional: ENV['COVERAGE']!='yes' do
 end
 
 # Override gemspec for CI matrix builds.
-puppetversion = ENV['PUPPET_VERSION'] || '>= 6.29'
-gem 'puppet', puppetversion, :require => false
+gem 'puppet', ENV.fetch('PUPPET_VERSION', '>= 6.29'), :require => false


### PR DESCRIPTION
This now uses a similar setup as puppet-syntax. Sideeffect is that for Puppet 6 tests, we pull in the 6.29 version or newer, which has a fix to pin to concurrent-ruby 1.1 and older.