### PR TITLE
Adjust Puppet settings to match Puppet 8 defaults

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -22,6 +22,16 @@ RSpec.configure do |config|
   end
 end
 
+# Puppet 8 remove Legacy Facts and enable Strict Mode:
+# https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#legacy-facts
+# https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#strict-mode
+#
+# We want to use these settings as a common denominator for all versions of
+# Puppet with test modules against.
+Puppet[:include_legacy_facts] = false
+Puppet[:strict_variables] = true
+Puppet[:strict] = :error
+
 if ENV['DEBUG']
   Puppet::Util::Log.level = :debug
   Puppet::Util::Log.newdestination(:console)


### PR DESCRIPTION
Puppet 8 will ship without legacy facts and with strict mode enabled by
default.  Adjust CI settings to match this configuration for all
versions of Puppet in order to match the most stict and less permissive
configuration.  This is expected to help detecting some issues even
before Puppet 8.0.0 is released.
