### PR TITLE
Remove use of legacy facts

### DIFF
--- a/lib/voxpupuli/test/facts.rb
+++ b/lib/voxpupuli/test/facts.rb
@@ -51,7 +51,7 @@ def add_facts_for_metadata(metadata)
   metadata['dependencies'].each do |dependency|
     case normalize_module_name(dependency['name'])
     when 'camptocamp/systemd', 'puppet/systemd'
-      add_custom_fact :systemd, ->(os, facts) { facts['service_provider'] == 'systemd' }
+      add_custom_fact :systemd, ->(_os, facts) { facts['service_provider'] == 'systemd' }
     when 'puppetlabs/stdlib'
       add_stdlib_facts
     end
@@ -70,8 +70,9 @@ def add_stdlib_facts
 
   # Rough conversion of grepping in the puppet source:
   # grep defaultfor lib/puppet/provider/service/*.rb
-  add_custom_fact :service_provider, ->(os, facts) do
-    case facts[:osfamily].downcase
+  add_custom_fact :service_provider, ->(_os, facts) do
+    os = RSpec.configuration.facterdb_string_keys ? facts['os'] : facts[:os]
+    case os['family'].downcase
     when 'archlinux'
       'systemd'
     when 'darwin'
@@ -85,9 +86,9 @@ def add_stdlib_facts
     when 'openbsd'
       'openbsd'
     when 'redhat'
-      facts[:operatingsystemmajrelease].to_i >= 7 ? 'systemd' : 'redhat'
+      os['release']['major'].to_i >= 7 ? 'systemd' : 'redhat'
     when 'suse'
-      facts[:operatingsystemmajrelease].to_i >= 12 ? 'systemd' : 'redhat'
+      os['release']['major'].to_i >= 12 ? 'systemd' : 'redhat'
     when 'windows'
       'windows'
     else

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -131,19 +131,25 @@ describe 'add_facts_for_metadata' do
 
       it 'has systemd on Red Hat 7' do
         add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {osfamily: 'RedHat', operatingsystemmajrelease: '7'})
+        facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {
+          os: { 'family' => 'RedHat', 'release' => { 'major' => '7' } }
+        })
         expect(facts['systemd']).to be true
       end
 
       it 'has no systemd on Red Hat 6' do
         add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {osfamily: 'RedHat', operatingsystemmajrelease: '6'})
+        facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {
+          os: {'family' => 'RedHat', 'release' => { 'major' => '6' }}
+        })
         expect(facts['systemd']).to be false
       end
 
       it 'has no systemd on openbsd' do
         add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {osfamily: 'OpenBSD'})
+        facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {
+          os: { 'family' => 'OpenBSD' }
+        })
         expect(facts['systemd']).to be false
       end
     end


### PR DESCRIPTION
At some point soon, either facterdb will stop providing legacy facts or rspec-puppet-facts will be configurable to filter them out.  Either way, we should not rely on them in this gem and use the modern counterparts instead.