### PR TITLE
CI: for Puppet 7, use 7.24 or newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
           - "2.6"
           - "2.5"
         puppet:
-          - "~> 7.0"
+          - "~> 7.24"
           - "~> 6.29"
         exclude:
           - ruby: "2.6"
-            puppet: "~> 7.0"
+            puppet: "~> 7.24"
           - ruby: "2.5"
-            puppet: "~> 7.0"
+            puppet: "~> 7.24"
 
           - ruby: "3.1"
             puppet: "~> 6.29"


### PR DESCRIPTION
This will prevent pulling in the broken 7.21 release or earlier, where ruby-concurrent in 1.2 is allowed, which is incompatible with Puppet.