### PR TITLE
Require Ruby 2.7 or newer, drop Puppet 6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,34 +20,14 @@ jobs:
           - "3.1"
           - "3.0"
           - "2.7"
-          - "2.6"
-          - "2.5"
         puppet:
           - "~> 8.0"
           - "~> 7.24"
-          - "~> 6.29"
         exclude:
           - ruby: "3.0"
             puppet: "~> 8.0"
           - ruby: "2.7"
             puppet: "~> 8.0"
-          - ruby: "2.6"
-            puppet: "~> 8.0"
-          - ruby: "2.5"
-            puppet: "~> 8.0"
-
-          - ruby: "2.6"
-            puppet: "~> 7.24"
-          - ruby: "2.5"
-            puppet: "~> 7.24"
-
-          - ruby: "3.2"
-            puppet: "~> 6.29"
-          - ruby: "3.1"
-            puppet: "~> 6.29"
-          - ruby: "3.0"
-            puppet: "~> 6.29"
-
     name: "Ruby ${{ matrix.ruby }} - Puppet ${{ matrix.puppet }}"
     env:
       PUPPET_VERSION: ${{ matrix.puppet }}

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['lib/**/*.rb', 'rubocop.yml']
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency 'rake'
 


### PR DESCRIPTION
I would like to start add Puppet 8 support. To do this properly, we need to bump a few gems and that means we need to drop Ruby 2.5 and 2.6 support.