### PR TITLE
gem dependencies: Add upper version limits

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -17,18 +17,18 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake'
 
   # Testing
-  s.add_runtime_dependency 'facterdb', '>= 1.4.0'
+  s.add_runtime_dependency 'facterdb', '>= 1.4.0', '< 2'
   s.add_runtime_dependency 'metadata-json-lint', '>= 3.0.1'
-  s.add_runtime_dependency 'parallel_tests'
+  s.add_runtime_dependency 'parallel_tests', '~> 4.2'
   # 4.0.0 provides rubocop annotations in GitHub Actions
   # 5.0.0 supports the validation of REFERENCE.md
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '>= 5.0.3'
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 6.0', '>= 6.0.1'
   # lazy dependency of the `validate` task. Will check the REFERENCE.md
   # 3.0.0 and later require Ruby 2.7
   s.add_runtime_dependency 'puppet-strings', '~> 4.0'
-  s.add_runtime_dependency 'rspec-puppet', '>= 2.11.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '>= 2.0.1', '< 3'
-  s.add_runtime_dependency 'rspec-puppet-utils', '>= 1.9.5'
+  s.add_runtime_dependency 'rspec-puppet', '~> 3.0'
+  s.add_runtime_dependency 'rspec-puppet-facts', '~> 2.0', '>= 2.0.5'
+  s.add_runtime_dependency 'rspec-puppet-utils', '~> 3.4'
 
   # Rubocop
   s.add_runtime_dependency 'rubocop', '~> 1.22.3'


### PR DESCRIPTION
This ensures that we don't pull in unexpected major versions.