### PR TITLE
always mock trusted/server facts

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -17,6 +17,10 @@ RSpec.configure do |config|
   # and 7.12+ and requires rspec-puppet 2.11.0+.
   config.facter_implementation = 'rspec'
 
+  # always mock trusted/server side facts
+  config.trusted_node_data = true
+  config.trusted_server_facts = true
+
   config.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end


### PR DESCRIPTION
Foreman does that in their modules and I think it makes sense to always enable it.