### PR TITLE
Gemfile: Allow Puppet 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ group :coverage, optional: ENV['COVERAGE']!='yes' do
 end
 
 # Override gemspec for CI matrix builds.
-gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 7.24'), :require => false
+gem 'puppet', ENV.fetch('PUPPET_VERSION', '>= 7.24'), :require => false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -7,6 +7,9 @@ require:
 AllCops:
   # Puppet agent 6 ships with ruby 2.5.  Puppetserver 6 uses JRuby 9.2.x (Ruby 2.5 compatible) since version 6.1.0.
   TargetRubyVersion: 2.5
+  DisplayCopNames: true
+  ExtraDetails: true
+  DisplayStyleGuide: true
   Include:
     - '**/*.rb'
   Exclude:


### PR DESCRIPTION
For the 8.0 we had to pin to 7.x because of a rubygems bug.