### PR TITLE
rspec-puppet-facts: Require 3.0.0

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   # and 7.12+ and requires rspec-puppet 2.11.0+.
   config.facter_implementation = 'rspec'
 
+  config.facterdb_string_keys = true
+
   config.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'voxpupuli/test/facts'
 
 describe 'override_facts' do
   let(:base_facts) do
@@ -132,7 +131,7 @@ describe 'add_facts_for_metadata' do
       it 'has systemd on Red Hat 7' do
         add_facts_for_metadata(metadata)
         facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {
-          os: { 'family' => 'RedHat', 'release' => { 'major' => '7' } }
+          'os' => { 'family' => 'RedHat', 'release' => { 'major' => '7' } }
         })
         expect(facts['systemd']).to be true
       end
@@ -140,7 +139,7 @@ describe 'add_facts_for_metadata' do
       it 'has no systemd on Red Hat 6' do
         add_facts_for_metadata(metadata)
         facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {
-          os: {'family' => 'RedHat', 'release' => { 'major' => '6' }}
+          'os' => {'family' => 'RedHat', 'release' => { 'major' => '6' }}
         })
         expect(facts['systemd']).to be false
       end
@@ -148,7 +147,7 @@ describe 'add_facts_for_metadata' do
       it 'has no systemd on openbsd' do
         add_facts_for_metadata(metadata)
         facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {
-          os: { 'family' => 'OpenBSD' }
+          'os' => { 'family' => 'OpenBSD' }
         })
         expect(facts['systemd']).to be false
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,4 @@ else
 end
 
 require 'rspec/core'
+require 'voxpupuli/test/spec_helper'

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   # 3.0.0 and later require Ruby 2.7
   s.add_runtime_dependency 'puppet-strings', '~> 4.0'
   s.add_runtime_dependency 'rspec-puppet', '~> 4.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '~> 2.0', '>= 2.0.5'
+  s.add_runtime_dependency 'rspec-puppet-facts', '~> 3.0'
   s.add_runtime_dependency 'rspec-puppet-utils', '~> 3.4'
 
   # Rubocop


### PR DESCRIPTION
I would like to release this as breaking change. That will require us to do a modulesync. That in turns ensures that we've a PR and a CI run for each module before we pull this change in.