### PR TITLE
don't stringify custom facts; require rspec-puppet-facts 3.x

### DIFF
--- a/lib/voxpupuli/test/facts.rb
+++ b/lib/voxpupuli/test/facts.rb
@@ -51,7 +51,7 @@ def add_facts_for_metadata(metadata)
   metadata['dependencies'].each do |dependency|
     case normalize_module_name(dependency['name'])
     when 'camptocamp/systemd', 'puppet/systemd'
-      add_custom_fact :systemd, ->(_os, facts) { facts['service_provider'] == 'systemd' }
+      add_custom_fact :systemd, ->(_os, facts) { facts[:service_provider] == 'systemd' }
     when 'puppetlabs/stdlib'
       add_stdlib_facts
     end
@@ -71,8 +71,7 @@ def add_stdlib_facts
   # Rough conversion of grepping in the puppet source:
   # grep defaultfor lib/puppet/provider/service/*.rb
   add_custom_fact :service_provider, ->(_os, facts) do
-    os = RSpec.configuration.facterdb_string_keys ? facts['os'] : facts[:os]
-    case os['family'].downcase
+    case facts[:os]['family'].downcase
     when 'archlinux'
       'systemd'
     when 'darwin'
@@ -86,9 +85,9 @@ def add_stdlib_facts
     when 'openbsd'
       'openbsd'
     when 'redhat'
-      os['release']['major'].to_i >= 7 ? 'systemd' : 'redhat'
+      facts[:os]['release']['major'].to_i >= 7 ? 'systemd' : 'redhat'
     when 'suse'
-      os['release']['major'].to_i >= 12 ? 'systemd' : 'redhat'
+      facts[:os]['release']['major'].to_i >= 12 ? 'systemd' : 'redhat'
     when 'windows'
       'windows'
     else

--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   # and 7.12+ and requires rspec-puppet 2.11.0+.
   config.facter_implementation = 'rspec'
 
+  config.facterdb_string_keys = true
+
   config.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -134,7 +134,7 @@ describe 'add_facts_for_metadata' do
         facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {
           os: { 'family' => 'RedHat', 'release' => { 'major' => '7' } }
         })
-        expect(facts['systemd']).to be true
+        expect(facts[:systemd]).to be true
       end
 
       it 'has no systemd on Red Hat 6' do
@@ -142,7 +142,7 @@ describe 'add_facts_for_metadata' do
         facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {
           os: {'family' => 'RedHat', 'release' => { 'major' => '6' }}
         })
-        expect(facts['systemd']).to be false
+        expect(facts[:systemd]).to be false
       end
 
       it 'has no systemd on openbsd' do
@@ -150,7 +150,7 @@ describe 'add_facts_for_metadata' do
         facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {
           os: { 'family' => 'OpenBSD' }
         })
-        expect(facts['systemd']).to be false
+        expect(facts[:systemd]).to be false
       end
     end
   end

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   # 3.0.0 and later require Ruby 2.7
   s.add_runtime_dependency 'puppet-strings', '~> 4.0'
   s.add_runtime_dependency 'rspec-puppet', '~> 4.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '~> 2.0', '>= 2.0.5'
+  s.add_runtime_dependency 'rspec-puppet-facts', '~> 3.0'
   s.add_runtime_dependency 'rspec-puppet-utils', '~> 3.4'
 
   # Rubocop


### PR DESCRIPTION
rspec-puppet-facts has an option to stringify all facts:

https://github.com/voxpupuli/rspec-puppet-facts/blob/fd600001c1cc9cb0bd2522188f4a8feb15f7cf40/lib/rspec-puppet-facts.rb#L176

But this is called *after* our facts are added:

https://github.com/voxpupuli/rspec-puppet-facts/blob/fd600001c1cc9cb0bd2522188f4a8feb15f7cf40/lib/rspec-puppet-facts.rb#L173

That means that voxpupuli-test doesn't need to care how RSpec.configuration.facterdb_string_keys is set. rspec-puppet-facts deal with it afterwards.