### PR TITLE
Use our spec_helper for tests

### DIFF
--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'voxpupuli/test/facts'
 
 describe 'override_facts' do
   let(:base_facts) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,4 @@ else
 end
 
 require 'rspec/core'
+require 'voxpupuli/test/spec_helper'


### PR DESCRIPTION
Previously our tests didn't honour our spec/spec_helper.rb. This configures some rspec defaults for our Puppet modules. It makes sense that our tests use the same settings. This revealed some problems in other PRs: https://github.com/voxpupuli/voxpupuli-test/pull/125