### PR TITLE
rspec-puppet-facts: Require 4.x; add custom facts as strings 

### DIFF
--- a/lib/voxpupuli/test/facts.rb
+++ b/lib/voxpupuli/test/facts.rb
@@ -51,7 +51,7 @@ def add_facts_for_metadata(metadata)
   metadata['dependencies'].each do |dependency|
     case normalize_module_name(dependency['name'])
     when 'camptocamp/systemd', 'puppet/systemd'
-      add_custom_fact :systemd, ->(_os, facts) { facts['service_provider'] == 'systemd' }
+      add_custom_fact :systemd, ->(_os, facts) { facts[:service_provider] == 'systemd' }
     when 'puppetlabs/stdlib'
       add_stdlib_facts
     end
@@ -86,7 +86,7 @@ def add_stdlib_facts
     when 'openbsd'
       'openbsd'
     when 'redhat'
-      os['release']['major'].to_i >= 7 ? 'systemd' : 'redhat'
+      'systemd'
     when 'suse'
       os['release']['major'].to_i >= 12 ? 'systemd' : 'redhat'
     when 'windows'

--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -17,6 +17,9 @@ RSpec.configure do |config|
   # and 7.12+ and requires rspec-puppet 2.11.0+.
   config.facter_implementation = 'rspec'
 
+  # In the next major release we will flip this to true
+  config.facterdb_string_keys = false
+
   config.after(:suite) do
     RSpec::Puppet::Coverage.report!
   end

--- a/spec/facts_spec.rb
+++ b/spec/facts_spec.rb
@@ -128,28 +128,20 @@ describe 'add_facts_for_metadata' do
         ]
       end
 
-      it 'has systemd on Red Hat 7' do
+      it 'has systemd on Red Hat 9' do
         add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('redhat-7-x86_64', {
-          os: { 'family' => 'RedHat', 'release' => { 'major' => '7' } }
+        facts = RspecPuppetFacts.with_custom_facts('redhat-9-x86_64', {
+          os: { 'family' => 'RedHat', 'release' => { 'major' => '9' } }
         })
-        expect(facts['systemd']).to be true
-      end
-
-      it 'has no systemd on Red Hat 6' do
-        add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('redhat-6-x86_64', {
-          os: {'family' => 'RedHat', 'release' => { 'major' => '6' }}
-        })
-        expect(facts['systemd']).to be false
+        expect(facts[:systemd]).to be true
       end
 
       it 'has no systemd on openbsd' do
         add_facts_for_metadata(metadata)
-        facts = RspecPuppetFacts.with_custom_facts('openbsd-6.4-x86_64', {
+        facts = RspecPuppetFacts.with_custom_facts('openbsd-7-x86_64', {
           os: { 'family' => 'OpenBSD' }
         })
-        expect(facts['systemd']).to be false
+        expect(facts[:systemd]).to be false
       end
     end
   end

--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake', '~> 13.0', '>= 13.0.6'
 
   # Testing
-  s.add_runtime_dependency 'facterdb', '>= 1.4.0', '< 2'
+  s.add_runtime_dependency 'facterdb', '~> 2.1'
   s.add_runtime_dependency 'metadata-json-lint', '~> 4.0'
   s.add_runtime_dependency 'parallel_tests', '~> 4.2'
   s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 7.3'
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   # 3.0.0 and later require Ruby 2.7
   s.add_runtime_dependency 'puppet-strings', '~> 4.0'
   s.add_runtime_dependency 'rspec-puppet', '~> 4.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '~> 2.0', '>= 2.0.5'
+  s.add_runtime_dependency 'rspec-puppet-facts', '~> 4.0'
   s.add_runtime_dependency 'rspec-puppet-utils', '~> 3.4'
 
   # Rubocop


### PR DESCRIPTION
This basically drops factsets for facter 1, 2 and 3. So it drops support for Puppet 6 and older. However, we don't support those anymore in our modules, so this isn't a breaking change.

The newer FacterDB release also drop support for some operating systems that were EoL as well.