### PR TITLE
Remove redundant mock_with default to rspec

### DIFF
--- a/lib/voxpupuli/test/spec_helper.rb
+++ b/lib/voxpupuli/test/spec_helper.rb
@@ -1,12 +1,3 @@
-RSpec.configure do |config|
-  # puppetlabs_spec_helper defaults to mocha but emits a deprecation warning
-  # Vox Pupuli prefers rspec to avoid the deprecation warning unless explicitly
-  # set
-  if config.instance_variable_get(:@mock_framework).nil?
-    config.mock_with :rspec
-  end
-end
-
 require 'voxpupuli/test/facts'
 require 'puppetlabs_spec_helper/module_spec_helper'
 


### PR DESCRIPTION
Since `puppetlabs_spec_helper` 5.0.0 this is the default (https://github.com/puppetlabs/puppetlabs_spec_helper/commit/493f0cbc1c96a3fa67591f3936430a70af74847f) and our gemspec declares 7.3+ as the version, making this redundant.