### PR TITLE
puppetlabs_spec_helper: Require 8.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'facterdb', '~> 3.1'
   s.add_runtime_dependency 'metadata-json-lint', '~> 4.0'
   s.add_runtime_dependency 'parallel_tests', '~> 4.2'
-  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 7.3'
+  s.add_runtime_dependency 'puppetlabs_spec_helper', '~> 8.0'
   # lazy dependency of the `validate` task. Will check the REFERENCE.md
   # 3.0.0 and later require Ruby 2.7
   s.add_runtime_dependency 'puppet-strings', '~> 4.0'


### PR DESCRIPTION
PSH 8 drops some build tasks, that we don't use:

https://github.com/puppetlabs/puppetlabs_spec_helper/compare/v7.4.0...v8.0.0