### PR TITLE
Add syslog gem as dependency

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -27,6 +27,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rspec-puppet', '~> 5.0'
   s.add_runtime_dependency 'rspec-puppet-facts', '~> 5.0'
   s.add_runtime_dependency 'rspec-puppet-utils', '~> 3.4'
+  # puppet gem depends on syslog, but doesn't list it as explicit dependency
+  # until Ruby 3.4, syslog was part of MRI ruby core
+  # Add it here as workaround until we've an openvox gem to depend on
+  s.add_runtime_dependency 'syslog', '~> 0.3.0'
 
   # Rubocop
   # newest versions that still support Ruby 2.6


### PR DESCRIPTION
puppet gem depends on syslog, but doesn't list it as explicit dependency until Ruby 3.4, syslog was part of MRI ruby core
Add it here as workaround until we've an openvox gem to depend on

Without this, we get warnings like:

```
.../.vendor/ruby/3.3.0/gems/puppet-8.10.0/lib/puppet.rb:38: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
```