### PR TITLE
Correctly call sh() when validating Ruby files

### DIFF
--- a/lib/voxpupuli/test/rake/validate.rb
+++ b/lib/voxpupuli/test/rake/validate.rb
@@ -7,7 +7,7 @@ namespace :validate do
   desc 'Validate all .rb files'
   task :ruby do
     Dir['lib/**/*.rb'].each do |lib_file|
-      sh ['ruby', '-c', lib_file]
+      sh 'ruby', '-c', lib_file
     end
   end
 


### PR DESCRIPTION
Fixes: ce7b87c9fe9c ("Replace PSH with puppet_fixtures")