### PR TITLE
validate:ruby: Validate Ruby tasks

### DIFF
--- a/lib/voxpupuli/test/rake/validate.rb
+++ b/lib/voxpupuli/test/rake/validate.rb
@@ -6,7 +6,7 @@ require 'puppet-strings/tasks'
 namespace :validate do
   desc 'Validate all .rb files'
   task :ruby do
-    Dir['lib/**/*.rb'].each do |lib_file|
+    Dir['lib/**/*.rb', 'tasks/**/*.rb'].each do |lib_file|
       sh 'ruby', '-c', lib_file
     end
   end


### PR DESCRIPTION
It's common that Bolt tasks are written in Ruby. Since we already validate Ruby files in modules, we can also validate the tasks. Tested:

```console
puppet-aptly $ bundle exec irb
irb(main):001> require 'rake'
=> true
irb(main):002*     Dir['lib/**/*.rb', 'tasks/**/*.rb'].each do |lib_file|
irb(main):003*       sh 'ruby', '-c', lib_file
irb(main):004>     end ;
ruby -c lib/cli_helper.rb
Syntax OK
ruby -c tasks/mirror_create.rb
Syntax OK
ruby -c tasks/mirror_drop.rb
Syntax OK
ruby -c tasks/mirror_list.rb
Syntax OK
ruby -c tasks/mirror_update.rb
Syntax OK
ruby -c tasks/publish_drop.rb
Syntax OK
ruby -c tasks/publish_list.rb
Syntax OK
ruby -c tasks/publish_repo.rb
Syntax OK
ruby -c tasks/publish_snapshot.rb
Syntax OK
ruby -c tasks/publish_switch.rb
Syntax OK
ruby -c tasks/publish_update.rb
Syntax OK
ruby -c tasks/repo_add.rb
Syntax OK
ruby -c tasks/repo_create.rb
Syntax OK
ruby -c tasks/repo_drop.rb
Syntax OK
ruby -c tasks/repo_list.rb
Syntax OK
ruby -c tasks/repo_remove.rb
Syntax OK
ruby -c tasks/snapshot_create.rb
Syntax OK
ruby -c tasks/snapshot_drop.rb
Syntax OK
ruby -c tasks/snapshot_list.rb
Syntax OK
irb(main):005>
```

```
puppet-aptly $ ls tasks/
mirror_create.json  mirror_update.json  publish_repo.json      publish_update.json  repo_drop.json    snapshot_create.json
mirror_create.rb    mirror_update.rb    publish_repo.rb        publish_update.rb    repo_drop.rb      snapshot_create.rb
mirror_drop.json    publish_drop.json   publish_snapshot.json  repo_add.json        repo_list.json    snapshot_drop.json
mirror_drop.rb      publish_drop.rb     publish_snapshot.rb    repo_add.rb          repo_list.rb      snapshot_drop.rb
mirror_list.json    publish_list.json   publish_switch.json    repo_create.json     repo_remove.json  snapshot_list.json
mirror_list.rb      publish_list.rb     publish_switch.rb      repo_create.rb       repo_remove.rb    snapshot_list.rb
```