### PR TITLE
validate rake task: Add missing rake dependency

### DIFF
--- a/lib/voxpupuli/test/rake/validate.rb
+++ b/lib/voxpupuli/test/rake/validate.rb
@@ -2,6 +2,7 @@
 
 require 'metadata-json-lint/rake_task'
 require 'puppet-strings/tasks'
+require 'rake' # provides `sh` method
 
 namespace :validate do
   desc 'Validate all .rb files'


### PR DESCRIPTION
The validate:ruby rake task uses the `sh` method. That's provided by rake (???)

```
[1] pry(main)> show-method sh
Error: Couldn't locate a definition for sh
[2] pry(main)> require 'rake'
=> true
[3] pry(main)> show-method sh

From: /home/bastelfreak/code/voxpupuli-test/.vendor/ruby/3.4.0/gems/rake-13.2.1/lib/rake/file_utils.rb:15:
Owner: Rake::DSL
Visibility: private
Signature: sh(*cmd, &block)
Number of lines: 17

def sh(*cmd, &block)
  options = (Hash === cmd.last) ? cmd.pop : {}
  shell_runner = block_given? ? block : create_shell_runner(cmd)

  set_verbose_option(options)
  verbose = options.delete :verbose
  noop    = options.delete(:noop) || Rake::FileUtilsExt.nowrite_flag

  Rake.rake_output_message sh_show_command cmd if verbose

  unless noop
    res = (Hash === cmd.last) ? system(*cmd) : system(*cmd, options)
    status = $?
    status = Rake::PseudoStatus.new(1) if !res && status.nil?
    shell_runner.call(res, status)
  end
end
[4] pry(main)>
```

IMO clean coding recommends adding the explicit require statement where the method is used.