### PR TITLE
feat: switch Layout/DotPosition to 'leading'

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -280,7 +280,7 @@ Style/PreferredHashMethods:
   Enabled: True
 
 Layout/DotPosition:
-  EnforcedStyle: trailing
+  EnforcedStyle: leading
 
 Style/DoubleNegation:
   Enabled: True


### PR DESCRIPTION
Trailing dot is really easy to forget to put when adding multiple lines. It's much harder to forget it when it's leading.