### PR TITLE
openvox-strings: Allow 6.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Testing
   s.add_runtime_dependency 'facterdb', '~> 3.1'
   s.add_runtime_dependency 'metadata-json-lint', '>= 4.0', '< 6'
-  s.add_runtime_dependency 'openvox-strings', '~> 5.0'
+  s.add_runtime_dependency 'openvox-strings', '>= 5.0', '< 7'
   s.add_runtime_dependency 'parallel_tests', '>= 4.2', '< 6'
   s.add_runtime_dependency 'puppet_fixtures', '>= 0.1', '< 2'
   s.add_runtime_dependency 'puppet-syntax', '~> 6.0'


### PR DESCRIPTION
6.x only dropped Ruby 3.1 and older.