### PR TITLE
voxpupuli-puppet-lint-plugins: require 6.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   # Linting
   # meta gem to pull in all puppet-lint plugins + puppet-lint itself
-  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '~> 5.0'
+  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '~> 6.0'
 
   # development
   s.add_development_dependency 'rspec', '~> 3.12'


### PR DESCRIPTION
https://github.com/voxpupuli/voxpupuli-puppet-lint-plugins/releases/tag/6.0.0