### PR TITLE
Revert "Update rubocop-rspec requirement from ~> 2.20.0 to >= 2.20, < 3.8"

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   # jruby 9.3 in Puppetserver 7 is compatible with C Ruby 2.6
   s.add_runtime_dependency 'rubocop', '~> 1.50.0'
   s.add_runtime_dependency 'rubocop-rake', '~> 0.6.0'
-  s.add_runtime_dependency 'rubocop-rspec', '>= 2.20', '< 3.8'
+  s.add_runtime_dependency 'rubocop-rspec', '~> 2.20.0'
 
   # Linting
   # meta gem to pull in all puppet-lint plugins + puppet-lint itself


### PR DESCRIPTION
Reverts voxpupuli/voxpupuli-test#183

We don't want this in the next release, because it will cause a lot of rubocop related warnings that will block CI. We need to wait a bit with this until we update all rubocop versions and the rubocop.yml we ship. 
Adding skip-changelog because the PR we're reverting isn't released yet

