### PR TITLE
voxpupuli-puppet-lint-plugins: Allow 7.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   # Linting
   # meta gem to pull in all puppet-lint plugins + puppet-lint itself
-  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '~> 6.0'
+  s.add_runtime_dependency 'voxpupuli-puppet-lint-plugins', '>= 6.0', '< 8'
 
   # development
   s.add_development_dependency 'rspec', '~> 3.12'


### PR DESCRIPTION
This switches to puppet-lint 5.1 and pulls in additional plugins:

* puppet-lint-params_not_optional_with_undef-check
* puppet-lint-exec_idempotency-check