### PR TITLE
rspec-puppet-facts: Allow 6.x

### DIFF
--- a/voxpupuli-test.gemspec
+++ b/voxpupuli-test.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-syntax', '>= 6.0', '< 8'
   s.add_runtime_dependency 'rspec-github', '>= 2.0', '< 4'
   s.add_runtime_dependency 'rspec-puppet', '~> 5.0'
-  s.add_runtime_dependency 'rspec-puppet-facts', '~> 5.4'
+  s.add_runtime_dependency 'rspec-puppet-facts', '>= 5.4', '< 7'
   # openvox gem depends on syslog, but doesn't list it as explicit dependency
   # until Ruby 3.4, syslog was part of MRI ruby core
   # https://github.com/OpenVoxProject/puppet/issues/90


### PR DESCRIPTION
The 6 release brings in some changes (most important is FacterDB 4 support):

**Breaking changes:**

- Require Ruby 3.2 or newer [\#224](https://github.com/voxpupuli/rspec-puppet-facts/pull/224) ([bastelfreak](https://github.com/bastelfreak))
- CI: Dont validate puppet\_agent\_facter\_versions.json anymore [\#223](https://github.com/voxpupuli/rspec-puppet-facts/pull/223) ([bastelfreak](https://github.com/bastelfreak))
- Switch from facter to openfact [\#219](https://github.com/voxpupuli/rspec-puppet-facts/pull/219) ([bastelfreak](https://github.com/bastelfreak))

**Implemented enhancements:**

- puppet\_agent\_facter\_versions: Add OpenVox/OpenFact versions [\#228](https://github.com/voxpupuli/rspec-puppet-facts/pull/228) ([bastelfreak](https://github.com/bastelfreak))
- FacterDB: Allow 4.x [\#222](https://github.com/voxpupuli/rspec-puppet-facts/pull/222) ([dependabot[bot]](https://github.com/apps/dependabot))