### PR TITLE
CI: Output bundle environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Display Ruby environment
+        run: bundle env
       - name: Build gem
         run: gem build --strict --verbose *.gemspec
       - name: Run tests


### PR DESCRIPTION
This makes it easier to debug Ruby failures. We introduced this in gha-puppet:

https://github.com/voxpupuli/gha-puppet/commit/fcf484bf4280d8d80b4a55999d122e81089640bc